### PR TITLE
Format day and month display values

### DIFF
--- a/README.md
+++ b/README.md
@@ -95,6 +95,8 @@ react-native run-ios
 |locale | the locale of area | Object | import from 'rmc-date-picker/lib/locale/en_US' |
 |onDateChange | Date change handler. | Function(date: moment) | '' |
 |minuteStep | The amount of time, in minutes, between each minute item. | Number | 1 |
+|formatMonth | Customize display value of months. Use [moment.js display tokens](http://momentjs.com/docs/#/displaying/format/) | String | |
+|formatDay | Customize display value of days. Use [moment.js display tokens](http://momentjs.com/docs/#/displaying/format/) | String | |
 
 ### rmc-date-picker/lib/Popup props
 

--- a/src/DatePickerMixin.tsx
+++ b/src/DatePickerMixin.tsx
@@ -149,7 +149,7 @@ export default {
   },
 
   getDateData() {
-    const locale = this.props.locale;
+    const { locale, formatMonth, formatDay } = this.props;
     const date = this.getDate();
     const selYear = date.year();
     const selMonth = date.month();
@@ -177,9 +177,10 @@ export default {
       maxMonth = maxDateMonth;
     }
     for (let i = minMonth; i <= maxMonth; i++) {
+      const label = formatMonth ? moment().month(i).format(formatMonth) : i + 1;
       months.push({
         value: i,
-        label: (i + 1) + locale.month,
+        label: (label) + locale.month,
       });
     }
 
@@ -194,9 +195,10 @@ export default {
       maxDay = maxDateDay;
     }
     for (let i = minDay; i <= maxDay; i++) {
+      const label = formatDay ? date.clone().date(i).format(formatDay) : i;
       days.push({
         value: i,
-        label: i + locale.day,
+        label: label + locale.day,
       });
     }
     return [years, months, days];

--- a/src/DatePickerProps.tsx
+++ b/src/DatePickerProps.tsx
@@ -7,6 +7,8 @@ interface DatePickerProps {
   disabled?: boolean;
   locale?: any;
   minuteStep?: number;
+  formatMonth?: string;
+  formatDay?: string;
   onDateChange?: (date: any) => void;
   /** web only */
   prefixCls?: string;


### PR DESCRIPTION
Rationale: Make it easier to see what is month and day (in our own locale). 

![out](https://cloud.githubusercontent.com/assets/230841/20785930/29646ff6-b7a3-11e6-9221-fad19783caaa.gif)

Does not affect default display value. 