### PR TITLE
fixed: the defaultDate is not between the minDate and maxDate

### DIFF
--- a/src/DatePicker.tsx
+++ b/src/DatePicker.tsx
@@ -154,7 +154,7 @@ class DatePicker extends React.Component<IDatePickerProps, any> {
   }
 
   getDate() {
-    return this.state.date || this.getDefaultMinDate();
+    return this.clipDate(this.state.date || this.getDefaultMinDate());
   }
 
   // used by rmc-picker/lib/PopupMixin.js


### PR DESCRIPTION
There are some errors when the defaultDate is not between the minDate and maxDate.

![](https://raw.githubusercontent.com/jiangleo/m-date-picker/image/doc/ezgif-4-697e35bf9b%202.gif)