### PR TITLE
Added a more easy-to-use mode for the user select a precise time in the most recent period.

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,7 +67,7 @@ online example: http://react-component.github.io/m-date-picker/
 
 ```
 npm run watch-tsc
-./node_modules/rc-tools run react-native-init
+npm run rn-init
 react-native run-ios
 ```
 

--- a/README.md
+++ b/README.md
@@ -97,6 +97,8 @@ react-native run-ios
 |onValueChange | fire when picker change | (vals: any, index: number) => void |  |
 |formatMonth | Customize display value of months | (month:number, current:Date) => React.Node | |
 |formatDay | Customize display value of days | (day:number, current:Date) => React.Node | |
+|formatRecentDate | only use in `recenttime` mode. Customize display value of recent date | (year: number, month: number, day:number, current:Date) => React.Node | |
+
 
 ### rmc-date-picker/lib/Popup props
 

--- a/README.md
+++ b/README.md
@@ -87,7 +87,7 @@ react-native run-ios
 |pickerPrefixCls(web) | picker prefix class | String | 'rmc-picker' |
 |defaultDate | default selected date. | Date | |
 |date | The currently selected date. | Date |  |
-|mode | The date picker mode. | String | 'date' enum('date', 'time', 'datetime', 'year', 'month') |
+|mode | The date picker mode. | String | 'date' enum('date', 'time', 'datetime', 'year', 'month', 'recenttime') |
 |minDate | min date | Date | 2000-1-1 |
 |maxDate | max date | Date | 2030-1-1 |
 |locale | the locale of area | Object | import from 'rmc-date-picker/lib/locale/en_US' |

--- a/package.json
+++ b/package.json
@@ -28,6 +28,7 @@
     "port": 8007
   },
   "scripts": {
+    "rn-init": "rc-tools run react-native-init",
     "watch-tsc": "rc-tools run watch-tsc",
     "compile": "rc-tools run compile --babel-runtime",
     "build": "rc-tools run build",

--- a/src/DatePicker.tsx
+++ b/src/DatePicker.tsx
@@ -31,7 +31,7 @@ const smallPickerItem = {
 };
 
 const DATETIME = 'datetime';
-const SINGLEDATE_TIME = 'singledate_time';
+const RECENT_TIME = 'recenttime';
 const DATE = 'date';
 const TIME = 'time';
 const MONTH = 'month';
@@ -73,7 +73,7 @@ class DatePicker extends React.Component<IDatePickerProps, any> {
 
     const value = parseInt(values[index], 10);
 
-    if (mode === SINGLEDATE_TIME) {
+    if (mode === RECENT_TIME) {
 
       switch (index) {
         case 0:
@@ -316,10 +316,12 @@ class DatePicker extends React.Component<IDatePickerProps, any> {
     ];
   }
 
-  getDayData = () => {
-    const {formatSingleDate, locale, formatMonth, formatDay,minDate,maxDate} = this.props;
+  getRecentDateData = () => {
+    const {formatSingleDate, locale, formatMonth, formatDay,} = this.props;
     const singleDate = [];
     const date = this.getDate();
+    const minDate = this.getMinDate()
+    const maxDate= this.getMaxDate();
 
     for (let d = minDate; d <= maxDate; d = increaseDay(d)) {
       const year = d.getFullYear();
@@ -380,7 +382,7 @@ class DatePicker extends React.Component<IDatePickerProps, any> {
     const minDateHour = this.getMinHour();
     const maxDateHour = this.getMaxHour();
     const hour = date.getHours();
-    if (mode === DATETIME) {
+    if (mode === DATETIME || mode === RECENT_TIME) {
       const year = date.getFullYear();
       const month = date.getMonth();
       const day = date.getDate();
@@ -452,7 +454,7 @@ class DatePicker extends React.Component<IDatePickerProps, any> {
     const {mode} = this.props;
     const minDate = this.getMinDate();
     const maxDate = this.getMaxDate();
-    if (mode === DATETIME) {
+    if (mode === DATETIME || mode === RECENT_TIME) {
       if (date < minDate) {
         return cloneDate(minDate);
       }
@@ -505,7 +507,7 @@ class DatePicker extends React.Component<IDatePickerProps, any> {
     }
 
 
-    if (mode === SINGLEDATE_TIME) {
+    if (mode === RECENT_TIME) {
       cols = this.getDayData();
       value = [`${date.getFullYear()}-${date.getMonth()}-${date.getDate()}`];
     }
@@ -517,7 +519,7 @@ class DatePicker extends React.Component<IDatePickerProps, any> {
     }
 
 
-    if (mode === SINGLEDATE_TIME || mode === DATETIME || mode === TIME) {
+    if (mode === RECENT_TIME || mode === DATETIME || mode === TIME) {
       cols = cols.concat(this.getTimeData());
       const hour = date.getHours();
       let dtValue = [hour + '', date.getMinutes() + ''];

--- a/src/DatePicker.tsx
+++ b/src/DatePicker.tsx
@@ -317,7 +317,7 @@ class DatePicker extends React.Component<IDatePickerProps, any> {
   }
 
   getRecentDateData = () => {
-    const {formatSingleDate, locale, formatMonth, formatDay,} = this.props;
+    const {formatRecentDate, locale, formatMonth, formatDay,} = this.props;
     const singleDate = [];
     const date = this.getDate();
     const minDate = this.getMinDate()
@@ -336,8 +336,8 @@ class DatePicker extends React.Component<IDatePickerProps, any> {
       const dLabel = formatDay ? formatDay(day, date) : (day + locale.day + '');
 
       const value = `${yValue}-${mValue}-${dValue}`;
-      const label = formatSingleDate ?
-        formatSingleDate(yLabel, mLabel, dLabel, date) :
+      const label = formatRecentDate ?
+        formatRecentDate(yLabel, mLabel, dLabel, date) :
         `${yLabel}${mLabel}${dLabel}`;
 
       singleDate.push({

--- a/src/DatePicker.tsx
+++ b/src/DatePicker.tsx
@@ -8,10 +8,6 @@ function getDaysInMonth(date) {
   return new Date(date.getFullYear(), date.getMonth() + 1, 0).getDate();
 }
 
-function getDaysWithYearAndMonth(year, month) {
-  return new Date(year, month + 1, 0).getDate();
-}
-
 function increaseDay(date) {
   return new Date(date.getTime() + ONE_DAY)
 }
@@ -33,10 +29,9 @@ function setMonth(date, month) {
 const smallPickerItem = {
   fontSize: 20,
 };
-// mode === DATETIME || mode === DATE || mode === YEAR || mode === MONTH
-// const MIXDATETIME = 'mixdatetime';
+
 const DATETIME = 'datetime';
-const SINGLEDATETIME = 'singledatetime';
+const SINGLEDATE_TIME = 'singledate_time';
 const DATE = 'date';
 const TIME = 'time';
 const MONTH = 'month';
@@ -78,7 +73,7 @@ class DatePicker extends React.Component<IDatePickerProps, any> {
 
     const value = parseInt(values[index], 10);
 
-    if (mode === SINGLEDATETIME) {
+    if (mode === SINGLEDATE_TIME) {
 
       switch (index) {
         case 0:
@@ -510,7 +505,7 @@ class DatePicker extends React.Component<IDatePickerProps, any> {
     }
 
 
-    if (mode === SINGLEDATETIME) {
+    if (mode === SINGLEDATE_TIME) {
       cols = this.getDayData();
       value = [`${date.getFullYear()}-${date.getMonth()}-${date.getDate()}`];
     }
@@ -522,7 +517,7 @@ class DatePicker extends React.Component<IDatePickerProps, any> {
     }
 
 
-    if (mode === SINGLEDATETIME || mode === DATETIME || mode === TIME) {
+    if (mode === SINGLEDATE_TIME || mode === DATETIME || mode === TIME) {
       cols = cols.concat(this.getTimeData());
       const hour = date.getHours();
       let dtValue = [hour + '', date.getMinutes() + ''];


### PR DESCRIPTION
There is no one fit in the existing `mode`, when I only need to select a precise time in the most recent period.

So, I add a `recenttime` option to the `mode` and add a `formatSingleDate` method.

![](https://raw.githubusercontent.com/jiangleo/m-date-picker/image/doc/recent.gif)