### PR TITLE
 Use better import syntax of ts + react

### DIFF
--- a/src/DatePicker.tsx
+++ b/src/DatePicker.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import * as React from 'react';
 import MultiPicker from 'rmc-picker/lib/MultiPicker';
 import Picker from 'rmc-picker/lib/Picker';
 import IDatePickerProps from './IDatePickerProps';

--- a/src/Popup.tsx
+++ b/src/Popup.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import * as React from 'react';
 import IDatePickerProps from './IDatePickerProps';
 import PopupPicker from 'rmc-picker/lib/Popup';
 import { IPopupPickerProps } from 'rmc-picker/lib/PopupPickerTypes';

--- a/tests/DatePicker.spec.js
+++ b/tests/DatePicker.spec.js
@@ -1,4 +1,4 @@
-import React from 'react';
+import * as React from 'react';
 import { render/*, mount*/ } from 'enzyme';
 import { renderToJson } from 'enzyme-to-json';
 import DatePicker from '../src';


### PR DESCRIPTION
This is not recommended for ts:
```import React from 'react';```
(This syntax need very specific tsconfig, which my project and many others would not met, and cause Error: `ERROR in node_modules/rmc-date-picker/lib/DatePicker.d.ts(1,8):
TS1192: Module '"node_modules/@types/react/index"' has no default export.
`)

So I changed them into 
```import * as React from 'react';```
