### PR TITLE
Added dateOrder prop to have configurable columns

### DIFF
--- a/src/DatePicker.tsx
+++ b/src/DatePicker.tsx
@@ -74,11 +74,10 @@ class DatePicker extends React.Component<IDatePickerProps, any> {
           DAY_ORDER,
           HOUR_ORDER,
           MINUTE_ORDER,
-          AMPM_ORDER,
         ];
       }
       if (mode === TIME) {
-        dateOrder = [HOUR_ORDER, MINUTE_ORDER, AMPM_ORDER];
+        dateOrder = [HOUR_ORDER, MINUTE_ORDER];
       }
       if (mode === DATE) {
         dateOrder = [DAY_ORDER, MONTH_ORDER, YEAR_ORDER];
@@ -88,6 +87,9 @@ class DatePicker extends React.Component<IDatePickerProps, any> {
       }
       if (mode === MONTH) {
         dateOrder = [YEAR_ORDER, MONTH_ORDER];
+      }
+      if (props.use12Hours && (mode === DATETIME || mode === TIME)) {
+        dateOrder!.push(AMPM_ORDER);
       }
     }
     this.dateIndex = {

--- a/src/IDatePickerProps.tsx
+++ b/src/IDatePickerProps.tsx
@@ -25,6 +25,7 @@ interface IDatePickerProps {
   pickerPrefixCls?: string;
   className?: string;
   use12Hours?: boolean;
+  dateOrder?: string[];
 }
 
 export default IDatePickerProps;


### PR DESCRIPTION
By default dateOrder will be same as old behaviour which for DATETIME mode, it will be ['y','M', 'd', 'H', 'M']
if use12Hours is true then 
 ['y','M', 'd', 'H', 'M', 'ampm']

where below is mapping for corresponding constants
const DAY_ORDER = 'd';
const MONTH_ORDER = 'M';
const YEAR_ORDER = 'y';
const HOUR_ORDER = 'H';
const MINUTE_ORDER = 'm';
const AMPM_ORDER = 'ampm';


User can give dateOrder in any manner.

for example for showing day before year, it should be ['d', 'M', 'y', 'H', 'M', 'ampm']
