### PR TITLE
Feature/multiple date format

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,8 +1,8 @@
 # rmc-date-picker
+
 ---
 
 React Mobile DatePicker Component (web and react-native)
-
 
 [![NPM version][npm-image]][npm-url]
 ![react-native](https://img.shields.io/badge/react--native-%3E%3D_0.30.0-green.svg)
@@ -51,9 +51,9 @@ npm start
 
 ## Example
 
-http://localhost:8000/examples/
+<http://localhost:8000/examples/>
 
-online example: http://react-component.github.io/m-date-picker/
+online example: <http://react-component.github.io/m-date-picker/>
 
 ## react-native
 
@@ -67,7 +67,6 @@ react-native run-ios
 ## install
 
 [![rmc-date-picker](https://nodei.co/npm/rmc-date-picker.png)](https://npmjs.org/package/rmc-date-picker)
-
 
 ## API
 
@@ -94,6 +93,7 @@ react-native run-ios
 |onValueChange | fire when picker change | (vals: any, index: number) => void |  |
 |formatMonth | Customize display value of months | (month:number, current:Date) => React.Node | |
 |formatDay | Customize display value of days | (day:number, current:Date) => React.Node | |
+|format | Customize year、month、day sequence | string:[] | ['year','month','date'] |
 
 ### rmc-date-picker/lib/Popup props
 
@@ -114,7 +114,6 @@ react-native run-ios
 |okText | ok button text | string/React.ReactElement | 'Ok' |
 |dismissText | dismiss button text | string/React.ReactElement | 'Dismiss' |
 |title | Popup title | string/React.ReactElement | '' |
-
 
 ## Test Case
 

--- a/examples/popup.tsx
+++ b/examples/popup.tsx
@@ -13,8 +13,9 @@ import { cn, format, minDate, maxDate, now } from './utils';
 
 class Demo extends React.Component<any, any> {
   static defaultProps = {
-    mode: 'datetime',
-    locale: cn ? zhCn : enUs,
+    mode: 'year',
+    // locale: cn ? zhCn : enUs,
+    locale: zhCn
   };
 
   constructor(props) {
@@ -50,6 +51,7 @@ class Demo extends React.Component<any, any> {
         defaultDate={now}
         mode={props.mode}
         locale={props.locale}
+        format={['day', 'month', ]}
       />
     );
     return (<div style={{ margin: '10px 30px' }}>

--- a/examples/popup.tsx
+++ b/examples/popup.tsx
@@ -13,7 +13,7 @@ import { cn, format, minDate, maxDate, now } from './utils';
 
 class Demo extends React.Component<any, any> {
   static defaultProps = {
-    mode: 'year',
+    mode: 'datetime',
     locale: cn ? zhCn : enUs,
   };
 
@@ -50,7 +50,7 @@ class Demo extends React.Component<any, any> {
         defaultDate={now}
         mode={props.mode}
         locale={props.locale}
-        format={['year', 'month', 'day']}
+        format={['month', 'day', 'year']}
       />
     );
     return (<div style={{ margin: '10px 30px' }}>

--- a/examples/popup.tsx
+++ b/examples/popup.tsx
@@ -14,8 +14,7 @@ import { cn, format, minDate, maxDate, now } from './utils';
 class Demo extends React.Component<any, any> {
   static defaultProps = {
     mode: 'year',
-    // locale: cn ? zhCn : enUs,
-    locale: zhCn
+    locale: cn ? zhCn : enUs,
   };
 
   constructor(props) {
@@ -51,7 +50,7 @@ class Demo extends React.Component<any, any> {
         defaultDate={now}
         mode={props.mode}
         locale={props.locale}
-        format={['day', 'month', ]}
+        format={['year', 'month', 'day']}
       />
     );
     return (<div style={{ margin: '10px 30px' }}>

--- a/src/DatePicker.tsx
+++ b/src/DatePicker.tsx
@@ -228,7 +228,7 @@ class DatePicker extends React.Component<IDatePickerProps, any> {
   }
 
   getDateData() {
-    const { locale, formatMonth, formatDay, mode, format } = this.props;
+    const { locale, formatMonth, formatDay, mode } = this.props;
     const date = this.getDate();
     const selYear = date.getFullYear();
     const selMonth = date.getMonth();
@@ -484,15 +484,12 @@ class DatePicker extends React.Component<IDatePickerProps, any> {
   getFormatArray = () => {
     const props = this.props;
     const { mode, format = [] } = props;
-    let defaultFormat: string[] = [];
-    let formatArray = format || defaultFormat;
+    let formatArray = format;
     if (mode === DATETIME || mode === DATE) {
-      defaultFormat = ['year', 'month', 'day'];
-      formatArray = formatArray.length === 3 ? formatArray : defaultFormat;
+      formatArray = formatArray.length === 3 ? formatArray : ['year', 'month', 'day'];
     } else if (mode === MONTH) {
-      defaultFormat = ['year', 'month'];
       formatArray = formatArray.length === 2 ? formatArray : ['year', 'month'];
-      formatArray = format.filter((item) => {
+      formatArray = formatArray.filter((item) => {
         return item !== 'day';
       });
     } else if (mode === YEAR) {

--- a/src/DatePicker.tsx
+++ b/src/DatePicker.tsx
@@ -62,16 +62,24 @@ class DatePicker extends React.Component<IDatePickerProps, any> {
     const { mode } = props;
     let newValue = cloneDate(this.getDate());
     if (mode === DATETIME || mode === DATE || mode === YEAR || mode === MONTH) {
-      switch (index) {
+      let type:any = index;
+      const formatArray = this.getFormatArray();
+      if( formatArray.length >= 1 && (index + 1 <= formatArray.length)) {
+        type = formatArray[index]
+      }
+      switch (type) {
         case 0:
+        case 'year':
           newValue.setFullYear(value);
           break;
         case 1:
+        case 'month':
           // Note: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Date/setMonth
           // e.g. from 2017-03-31 to 2017-02-28
           setMonth(newValue, value);
           break;
         case 2:
+        case 'day':
           newValue.setDate(value);
           break;
         case 3:
@@ -220,7 +228,7 @@ class DatePicker extends React.Component<IDatePickerProps, any> {
   }
 
   getDateData() {
-    const { locale, formatMonth, formatDay, mode } = this.props;
+    const { locale, formatMonth, formatDay, mode, format } = this.props;
     const date = this.getDate();
     const selYear = date.getFullYear();
     const selMonth = date.getMonth();
@@ -260,7 +268,15 @@ class DatePicker extends React.Component<IDatePickerProps, any> {
     }
     const monthCol = { key: 'month', props: { children: months } };
     if (mode === MONTH) {
-      return [yearCol, monthCol];
+      const formatArray = this.getFormatArray();
+      const dateSequence = formatArray.map((item) => {
+        if (item === 'year') {
+          return yearCol;
+        } else if (item === 'month') {
+          return monthCol;
+        }
+      });
+      return dateSequence;
     }
 
     const days: any[] = [];
@@ -280,11 +296,17 @@ class DatePicker extends React.Component<IDatePickerProps, any> {
         label,
       });
     }
-    return [
-      yearCol,
-      monthCol,
-      { key: 'day', props: { children: days } },
-    ];
+    const formatArray = this.getFormatArray();
+    const dateSequence = formatArray.map((item) => {
+      if (item === 'year') {
+        return yearCol;
+      } else if (item === 'month') {
+        return monthCol;
+      } else if (item === 'day') {
+        return { key: 'day', props: { children: days } };
+      }
+    });
+    return dateSequence;
   }
 
   getDisplayHour(rawHour) {
@@ -422,24 +444,23 @@ class DatePicker extends React.Component<IDatePickerProps, any> {
     const date = this.getDate();
     let cols: any[] = [];
     let value: any[] = [];
-
     if (mode === YEAR) {
       return {
         cols: this.getDateData(),
-        value: [date.getFullYear() + ''],
+        value: this.formatValue(),
       };
     }
 
     if (mode === MONTH) {
       return {
         cols: this.getDateData(),
-        value: [date.getFullYear() + '', date.getMonth() + ''],
+        value: this.formatValue(),
       };
     }
 
     if (mode === DATETIME || mode === DATE) {
       cols = this.getDateData();
-      value = [date.getFullYear() + '', date.getMonth() + '', date.getDate() + ''];
+      value = this.formatValue();
     }
 
     if (mode === DATETIME || mode === TIME) {
@@ -458,6 +479,41 @@ class DatePicker extends React.Component<IDatePickerProps, any> {
       value,
       cols,
     };
+  }
+
+  getFormatArray = () => {
+    const props = this.props;
+    const { mode, format = [] } = props;
+    let defaultFormat:string[] = [];
+    let formatArray = format || defaultFormat;
+    if(mode === DATETIME || mode === DATE) {
+      defaultFormat = ['year', 'month', 'day'];
+      formatArray = formatArray.length === 3 ? formatArray : defaultFormat;
+    } else if (mode === MONTH) {
+      defaultFormat = ['year', 'month'];
+      formatArray = formatArray.length === 2 ? formatArray : ['year', 'month'];
+      formatArray = format.filter((item) => {
+        return item !== 'day';
+      })
+    } else if(mode === YEAR) {
+      formatArray = ['year'];
+    }
+    return formatArray;
+  }
+
+  formatValue = () => {
+    const formatArray = this.getFormatArray();
+    const date = this.getDate();
+    const values = formatArray.map((item) => {
+      if (item === 'year') {
+        return date.getFullYear() + '';
+      } else if (item === 'month') {
+        return date.getMonth() + '';
+      } else if (item === 'day') {
+        return date.getDate() + '';
+      }
+    });
+    return values;
   }
 
   render() {

--- a/src/DatePicker.tsx
+++ b/src/DatePicker.tsx
@@ -62,10 +62,10 @@ class DatePicker extends React.Component<IDatePickerProps, any> {
     const { mode } = props;
     let newValue = cloneDate(this.getDate());
     if (mode === DATETIME || mode === DATE || mode === YEAR || mode === MONTH) {
-      let type:any = index;
+      let type = index;
       const formatArray = this.getFormatArray();
-      if( formatArray.length >= 1 && (index + 1 <= formatArray.length)) {
-        type = formatArray[index]
+      if ( formatArray.length >= 1 && (index + 1 <= formatArray.length)) {
+        type = formatArray[index];
       }
       switch (type) {
         case 0:
@@ -484,9 +484,9 @@ class DatePicker extends React.Component<IDatePickerProps, any> {
   getFormatArray = () => {
     const props = this.props;
     const { mode, format = [] } = props;
-    let defaultFormat:string[] = [];
+    let defaultFormat: string[] = [];
     let formatArray = format || defaultFormat;
-    if(mode === DATETIME || mode === DATE) {
+    if (mode === DATETIME || mode === DATE) {
       defaultFormat = ['year', 'month', 'day'];
       formatArray = formatArray.length === 3 ? formatArray : defaultFormat;
     } else if (mode === MONTH) {
@@ -494,8 +494,8 @@ class DatePicker extends React.Component<IDatePickerProps, any> {
       formatArray = formatArray.length === 2 ? formatArray : ['year', 'month'];
       formatArray = format.filter((item) => {
         return item !== 'day';
-      })
-    } else if(mode === YEAR) {
+      });
+    } else if (mode === YEAR) {
       formatArray = ['year'];
     }
     return formatArray;

--- a/src/IDatePickerProps.tsx
+++ b/src/IDatePickerProps.tsx
@@ -25,7 +25,7 @@ interface IDatePickerProps {
   pickerPrefixCls?: string;
   className?: string;
   use12Hours?: boolean;
-  format?: string[]
+  format?: string[];
 }
 
 export default IDatePickerProps;

--- a/src/IDatePickerProps.tsx
+++ b/src/IDatePickerProps.tsx
@@ -25,6 +25,7 @@ interface IDatePickerProps {
   pickerPrefixCls?: string;
   className?: string;
   use12Hours?: boolean;
+  format?: string[]
 }
 
 export default IDatePickerProps;


### PR DESCRIPTION
the default order of date picker is Year - Month - Day
However some countries use Month - Day - Year  format or Day-Month-Year , so we need to support more format.
refers[date format](https://docs.oracle.com/cd/E19683-01/816-3981/overview-46/index.html)
Generally speaking, we just need change Year Month Day order , and don't need to change Hour Mins order. Because time format is always fixed.

目前在东南亚国家使用这套组件的时候，发现对本地化支持的不太好。参见[日期格式](https://docs.oracle.com/cd/E19683-01/816-3981/overview-46/index.html)。例如在泰国，我们希望的是月日年，而不是年月日，这和当地用户的使用习惯有较大差异。同时对于时间和分钟，我们却没有这样的换位需求，请参考[时间格式](https://docs.oracle.com/cd/E19683-01/816-3981/overview-44/index.html)
在查看Antd-mobile源码后发现，需要先改动rmc-date-picker，才能继续向ant-mobile提交代码，因此有了这个pull request.



![png](https://gw.alicdn.com/tfs/TB1cwE4Mhv1gK0jSZFFXXb0sXXa-415-707.png)